### PR TITLE
feat(cli): add yargs parser and tests

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,12 +6,16 @@
     "thumbgen": "dist/index.js"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "test": "node --import tsx --test ./src/index.test.ts"
   },
   "dependencies": {
-    "@thumbgen/imaging": "0.1.0"
+    "@thumbgen/imaging": "file:../imaging",
+    "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "tsx": "^4.7.0",
+    "@types/node": "^20.11.30"
   }
 }

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { buildParser } from './index.js';
+
+test('parses CLI options', async () => {
+  const argv = await buildParser(['-i', 'src', '-t', 'Title', '-o', 'out', '--size', '640x360', '--size', '800x600']).parseAsync();
+  assert.equal(argv.input, 'src');
+  assert.equal(argv.title, 'Title');
+  assert.equal(argv.out, 'out');
+  assert.deepEqual(argv.size, ['640x360', '800x600']);
+});
+
+test('uses defaults when options omitted', async () => {
+  const argv = await buildParser([]).parseAsync();
+  assert.equal(argv.input, '.');
+  assert.equal(argv.title, 'Sample — CLI');
+});
+
+test('includes options in help output', async () => {
+  const help = await buildParser([]).getHelp();
+  assert.match(help, /--input/);
+  assert.match(help, /--title/);
+  assert.match(help, /--out/);
+  assert.match(help, /--size/);
+});


### PR DESCRIPTION
## Summary
- use yargs to parse CLI arguments and add help output
- support input, title, out and size options
- add tests for argument parsing

## Testing
- `npm test` (packages/cli)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5eefac9248328b98d2227ca8e04f5