### PR TITLE
fix build by adding type declarations and upgrading deps

### DIFF
--- a/apps/api/dist/index.d.ts
+++ b/apps/api/dist/index.d.ts
@@ -1,2 +1,2 @@
-export declare const app: any;
+export declare const app: import("express-serve-static-core").Express;
 export default app;

--- a/apps/api/dist/index.js
+++ b/apps/api/dist/index.js
@@ -35,7 +35,8 @@ app.post("/api/generate", upload.array("images", 10), async (req, res) => {
         res.json({ ok: true, preview: base64, variants });
     }
     catch (e) {
-        res.status(500).json({ ok: false, error: e?.message || "failed" });
+        const message = e instanceof Error ? e.message : "failed";
+        res.status(500).json({ ok: false, error: message });
     }
 });
 if (process.env.NODE_ENV !== "test") {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,16 +9,17 @@
     "test": "vitest"
   },
   "dependencies": {
-    "express": "^4.19.2",
-    "multer": "^1.4.5-lts.1",
     "@thumbgen/imaging": "0.1.0",
-    "zod": "^3.23.8",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "multer": "^2.0.2",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
+    "supertest": "^7.1.1",
     "tsx": "^4.7.0",
     "typescript": "^5.4.0",
-    "vitest": "^1.6.0",
-    "supertest": "^7.1.1"
+    "vitest": "^3.2.4",
+    "vite": "^7.1.5"
   }
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,6 +2,7 @@ import express from "express";
 import cors from "cors";
 import multer from "multer";
 import { z } from "zod";
+import type { Express, Request, Response } from "express";
 import { generateThumbnail, UploadedImage } from "@thumbgen/imaging";
 
 export const app = express();
@@ -9,7 +10,7 @@ const upload = multer({ limits: { fileSize: 25 * 1024 * 1024 } });
 app.use(cors());
 app.use(express.json());
 
-app.get("/", (_req, res) => res.json({ ok: true, name: "thumbgen-api" }));
+app.get("/", (_req: Request, res: Response) => res.json({ ok: true, name: "thumbgen-api" }));
 
 const BodySchema = z.object({
   title: z.string().min(1)
@@ -17,7 +18,7 @@ const BodySchema = z.object({
 
 const FilesSchema = z.array(z.any()).min(1).max(10);
 
-app.post("/api/generate", upload.array("images", 10), async (req, res) => {
+app.post("/api/generate", upload.array("images", 10), async (req: Request, res: Response) => {
   const bodyResult = BodySchema.safeParse(req.body);
   const fileResult = FilesSchema.safeParse(req.files);
 
@@ -40,8 +41,9 @@ app.post("/api/generate", upload.array("images", 10), async (req, res) => {
       dataUrl: `data:image/png;base64,${v.buffer.toString("base64")}`
     }));
     res.json({ ok: true, preview: base64, variants });
-  } catch (e:unknown) {
-    res.status(500).json({ ok:false, error: e?.message || "failed" });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "failed";
+    res.status(500).json({ ok: false, error: message });
   }
 });
 

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@thumbgen/imaging": ["../../packages/imaging/src"]
+    }
   },
   "include": [
     "src"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,8 +17,9 @@
   "devDependencies": {
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
+    "@vitejs/plugin-react": "^5.0.2",
     "typescript": "^5.4.0",
-    "vite": "^5.2.0",
-    "vitest": "^1.6.0"
+    "vite": "^7.1.5",
+    "vitest": "^3.2.4"
   }
 }

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
   "license": "ISC",
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
+    "@types/cors": "^2.8.19",
+    "@types/express": "^5.0.3",
+    "@types/multer": "^2.0.0",
+    "@types/node": "^24.3.3",
+    "@types/yargs": "^17.0.33",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.43.0",
     "eslint": "^9.35.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,9 +14,10 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "typescript": "^5.4.0",
-    "tsx": "^4.7.0",
     "@types/node": "^20.11.30",
-    "vitest": "^1.6.0"
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0",
+    "vitest": "^3.2.4",
+    "vite": "^7.1.5"
   }
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@thumbgen/imaging": ["../imaging/src"]
+    }
   },
   "include": [
     "src"

--- a/packages/imaging/package.json
+++ b/packages/imaging/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "typescript": "^5.4.0",
-    "vitest": "^1.6.0"
+    "vitest": "^3.2.4",
+    "vite": "^7.1.5"
   }
 }

--- a/packages/imaging/tsconfig.json
+++ b/packages/imaging/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"],
+    "baseUrl": "."
   },
   "include": [
     "src"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,8 @@
     "declaration": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
   }
 }


### PR DESCRIPTION
## Summary
- add missing type packages and enable `esModuleInterop` to compile API and packages
- type Express handlers and improve error handling
- upgrade `multer`, `vite`, `vitest`, and add Vite React plugin

## Testing
- `CI=1 npm test`
- `npm run lint`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_68c5f7d9cb848328933adfebb72367f3