### PR TITLE
Improve variant thumbnail rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,12 @@
     "@types/yargs": "^17.0.33",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.43.0",
+    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.35.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
     "globals": "^16.4.0",
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/imaging/__tests__/generateThumbnail.test.ts
+++ b/packages/imaging/__tests__/generateThumbnail.test.ts
@@ -33,4 +33,20 @@ describe('imaging', () => {
     expect(sizes).toContainEqual({ width: 1080, height: 1080 });
     expect(sizes).toContainEqual({ width: 1080, height: 1920 });
   });
+
+  it('fills variant backgrounds with gradient colors', async () => {
+    const subject: UploadedImage = { id: 's', filename: 's.png', buffer: await colorImage(200, 100, 50, 300) };
+    const logo: UploadedImage = { id: 'l', filename: 'l.png', buffer: await colorImage(10, 20, 30, 40) };
+    const pal = await extractPalette(subject.buffer);
+    const res = await generateThumbnail([subject, logo]);
+    const variant = res.variants.find((v) => v.size.width === 1080 && v.size.height === 1080)!;
+    const pixel = await sharp(variant.buffer)
+      .extract({ left: 0, top: 0, width: 1, height: 1 })
+      .raw()
+      .toBuffer();
+    const [r, g, b] = [pal.dominant.slice(1, 3), pal.dominant.slice(3, 5), pal.dominant.slice(5, 7)].map((h) => parseInt(h, 16));
+    expect(Math.abs(pixel[0] - r)).toBeLessThan(5);
+    expect(Math.abs(pixel[1] - g)).toBeLessThan(5);
+    expect(Math.abs(pixel[2] - b)).toBeLessThan(5);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure full thumbnail layout preserved in generated variants by fitting base image into gradient background
- add vitest and coverage tooling for running tests
- add unit test validating gradient background colors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c60a61d2508328842c558c622c8668